### PR TITLE
feat: send commit hash with deploy request

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,8 @@ BRANCH_NAME=$(echo "$RAW_NAME" | tr '[:upper:]' '[:lower:]' | \
 HTTP_RESPONSE=$(curl --silent --location "${NIMBUS_SERVER}/deploy" --write-out "HTTPSTATUS:%{http_code}" \
     --header "X-Api-Key: ${NIMBUS_API_KEY}" \
     --form "file=@${NIMBUS_PATH}" \
-    --form "branch=${BRANCH_NAME}")
+    --form "branch=${BRANCH_NAME}" \
+    --form "commit=${GITHUB_SHA}")
 
 # Extract the body and the status code
 HTTP_BODY=$(echo "$HTTP_RESPONSE" | sed -e 's/HTTPSTATUS\:.*//g')


### PR DESCRIPTION
Pass GITHUB_SHA as the commit form field so the nimbus server can associate deployments with specific git commits.