### PR TITLE
docs: document custom ingress annotations support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,29 @@ jobs:
 
 Adding the `delete` event enables automatic cleanup of branch preview deployments when branches are deleted (e.g., after merging a PR). Tag deletions are ignored.
 
+## Custom Ingress Annotations
+
+Public `http` services can specify custom nginx ingress annotations via an
+`annotations` map in your `nimbus.yaml`. These are merged on top of Nimbus'
+defaults, so you can both append new annotations and override the built-ins
+(e.g. to wire up external auth):
+
+```yaml
+services:
+  - name: web
+    template: http
+    public: true
+    image: registry.example.com/web:latest
+    network:
+      ports: [8080]
+    annotations:
+      nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/auth-url: "https://idp.example.com/sessions/whoami"
+      nginx.ingress.kubernetes.io/auth-signin: "https://proxy.example.com/oauth2/start?rd=$scheme://$host$request_uri"
+```
+
+See the sample [`nimbus.yaml`](./nimbus.yaml) for a full example.
+
 ## Inputs
 
 | Environment       | Default       | Description                                    |

--- a/nimbus.yaml
+++ b/nimbus.yaml
@@ -9,6 +9,13 @@ services:
       ports:
         - 8080
     args: ["-listen=:8080", "-text=Hello from Nimbus!"]
+    # Custom ingress annotations are merged on top of Nimbus' defaults, so you
+    # can append new ones or override the built-ins (only applied to public
+    # http services).
+    annotations:
+      nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/auth-url: "https://idp.prayujt.com/sessions/whoami"
+      nginx.ingress.kubernetes.io/auth-signin: "https://proxy.prayujt.com/oauth2/start?rd=$scheme://$host$request_uri"
 
   - name: database
     template: postgres


### PR DESCRIPTION
Add an example `annotations` map to the sample nimbus.yaml and document the feature in the README. Nimbus merges these on top of its default ingress annotations for public http services.